### PR TITLE
Adds Phantomjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.4
+* Adds alpine specific version of phantomjs.
+
 ## 0.0.3
 * Use the official `php-fpm` alpine base image.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,6 @@ RUN set -xe; \
     # permissions
     usermod -u 1000 www-data && \
 
-    # phantomjs prebuilt binary
-    curl -Ls https://github.com/fgrehm/docker-phantomjs2/releases/download/v2.0.0-20150722/dockerized-phantomjs.tar.gz \
-       | tar xz -C / && \
-
     # cleanup
     apk del \
     autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ RUN set -xe; \
     # permissions
     usermod -u 1000 www-data && \
 
+    # phantomjs prebuilt binary
+    curl -Ls https://github.com/fgrehm/docker-phantomjs2/releases/download/v2.0.0-20150722/dockerized-phantomjs.tar.gz \
+       | tar xz -C / && \
+
     # cleanup
     apk del \
     autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM php:5.6-fpm-alpine
 MAINTAINER "The Impact Bot" <technology@bcorporation.net>
 
+ENV PHANTOMJS_ARCHIVE="phantomjs.tar.gz"
+
 RUN set -xe; \
     echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories && \
     apk add --no-cache \
@@ -26,6 +28,18 @@ RUN set -xe; \
     xdebug \
     memcached-2.2.0 && \
     docker-php-ext-enable xdebug memcached opcache && \
+
+    # phantomjs prebuilt binary
+    curl -Lk -o $PHANTOMJS_ARCHIVE https://github.com/fgrehm/docker-phantomjs2/releases/download/v2.0.0-20150722/dockerized-phantomjs.tar.gz && \
+    tar -xf $PHANTOMJS_ARCHIVE -C /tmp/ && \
+    cp -R /tmp/etc/fonts /etc/ && \
+    cp -R /tmp/lib/* /lib/ && \
+    cp -R /tmp/lib64 / && \
+    cp -R /tmp/usr/lib/* /usr/lib/ && \
+    cp -R /tmp/usr/lib/x86_64-linux-gnu /usr/ && \
+    cp -R /tmp/usr/share/* /usr/share/ && \
+    cp /tmp/usr/local/bin/phantomjs /usr/bin/ && \
+    rm -fr $PHANTOMJS_ARCHIVE  /tmp/* && \
 
     # permissions
     usermod -u 1000 www-data && \


### PR DESCRIPTION
For heroku, we use a composer package to include phantomJs, because heroku works w/ the standard phantomjs binaries.  There are some hoops to jump through to get phantomjs to compile on alpine though.  This includes some alpine compatible phantomjs binary in the docker image.

The tar file was originally created to be extracted to the root dir of the system, so there are some odd commands around extracting it to `/tmp` and copying the relevant files out to some target dirs.

